### PR TITLE
Fix issue with node creation in For Science!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 # Mono auto generated files
 mono_crash.*
 
+.idea
+
 # KSP dlls
 external_dlls/
 

--- a/NodeManagerProject/NodeManager.csproj
+++ b/NodeManagerProject/NodeManager.csproj
@@ -30,13 +30,13 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-		<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.0" PrivateAssets="all" />
+		<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
 		<PackageReference Include="BepInEx.Core" Version="5.*" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
 		<PackageReference Include="HarmonyX" Version="2.10.1" />
-		<PackageReference Include="SpaceWarp" Version="1.5.2" />
+		<PackageReference Include="SpaceWarp" Version="1.7.0" />
 		<PackageReference Include="UnityEngine.Modules" Version="2022.3.5" IncludeAssets="compile" />
-		<PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.1.5" PrivateAssets="all" />
+		<PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.2.0" PrivateAssets="all" Publicize="true" />
 	</ItemGroup>
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 		<Exec Command="REM copy dll, pdb images info files and readme to the Debug or Release Dir&#xD;&#xA;&#xD;&#xA;ECHO off&#xD;&#xA;SET DEST_DIR=$(ProjectDir)..\$(ConfigurationName)&#xD;&#xA;&#xD;&#xA;if not exist &quot;%25DEST_DIR%25&quot; rmdir /s /q &quot;%25DEST_DIR%25&quot;&#xD;&#xA;if not exist &quot;%25DEST_DIR%25&quot; mkdir &quot;%25DEST_DIR%25&quot;&#xD;&#xA;&#xD;&#xA;echo d | xcopy /y /s &quot;$(ProjectDir)..\$(ModId)\&quot; &quot;%25DEST_DIR%25\BepInEx\plugins\$(ModId)\&quot;&#xD;&#xA;echo f | xcopy /y &quot;$(TargetPath)&quot; &quot;%25DEST_DIR%25\BepInEx\plugins\$(ModId)\$(ModId).dll&quot;&#xD;&#xA;if $(ConfigurationName) == Debug echo f | xcopy /y &quot;$(TargetDir)$(TargetName).pdb&quot; &quot;%25DEST_DIR%25\BepInEx\plugins\$(ModId)\$(ModId).pdb&quot;&#xD;&#xA;xcopy /y &quot;$(ProjectDir)..\LICENSE.md&quot; &quot;%25DEST_DIR%25\BepInEx\plugins\$(ModId)\&quot;&#xD;&#xA;echo f | xcopy /y &quot;$(ProjectDir)..\README.md&quot; &quot;%25DEST_DIR%25\BepInEx\plugins\$(ModId)\README.txt&quot;&#xD;&#xA;&#xD;&#xA;cd $(ProjectDir)..\batches&#xD;&#xA;call post_build.bat $(ConfigurationName) $(ModId)" />

--- a/NodeManagerProject/NodeManager.csproj
+++ b/NodeManagerProject/NodeManager.csproj
@@ -8,7 +8,7 @@
 		<AssemblyName>com.github.schlosrat.node_manager</AssemblyName>
 		<Product>Node Manager</Product>
 		<Description>Provides services for other mods needing to create, delete, and manage maneuver nodes</Description>
-		<Version Label="Version of the mod">0.7.0</Version>
+		<Version Label="Version of the mod">0.7.1</Version>
 		<RestoreAdditionalProjectSources>
 			https://nuget.spacewarp.org/v3/index.json
 		</RestoreAdditionalProjectSources>
@@ -34,7 +34,7 @@
 		<PackageReference Include="BepInEx.Core" Version="5.*" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
 		<PackageReference Include="HarmonyX" Version="2.10.1" />
-		<PackageReference Include="SpaceWarp" Version="1.7.0" />
+		<PackageReference Include="SpaceWarp" Version="1.6.0" />
 		<PackageReference Include="UnityEngine.Modules" Version="2022.3.5" IncludeAssets="compile" />
 		<PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.2.0" PrivateAssets="all" Publicize="true" />
 	</ItemGroup>

--- a/NodeManagerProject/NodeManagerPlugin.cs
+++ b/NodeManagerProject/NodeManagerPlugin.cs
@@ -13,22 +13,23 @@ using SpaceWarp.API.Mods;
 using SpaceWarp.API.UI;
 using UnityEngine;
 using System.Collections;
+using JetBrains.Annotations;
 
 /* This mod is primarily meant as a service provider to other mods, which can call functions in this one
  * without needing to recreate all these functios in the base mod. To use this mod in your mod you will
  * need to do the following:
- * 
+ *
  * Add the node_manager.dll to your mods list of Assemblies. Generally, put the dll in the same folder
  * you hace Assembly-CSharp.dll in and add it to your csproj file the same way. Your mod will need to
- * have access to it this way during compile time. At run time your mod will be accessing the 
+ * have access to it this way during compile time. At run time your mod will be accessing the
  * node_manager.dll from the plugins folder where Node Manager is installed.
- * 
+ *
  * Bring in the NodeManger namespace
- * 
+ *
  *     using NodeManager;
- * 
+ *
  * Check to make sure Node Manager is loaded somewhere before you use it (e.g., OnInitialized())
- * 
+ *
     if (Chainloader.PluginInfos.TryGetValue(NodeManagerPlugin.ModGuid, var out NM))
     {
         NMLoaded = true;
@@ -36,10 +37,10 @@ using System.Collections;
         Logger.LogInfo($"MNC = {NM}");
     }
     else NMLoaded = false;
- * 
+ *
  * Create a reflection caller for each of the functions in this mod that you would like to call
  * similar to this example
- * 
+ *
     private void CreateNodeAtUt(Vector3d burnVector, double UT, double burnDurationOffsetFactor = -0.5)
     {
         if (NMLoaded)
@@ -56,7 +57,7 @@ using System.Collections;
     }
  *
  * Call your reflection method wherever you need to invoke the corresponding Node Manager method
- * 
+ *
  * Profit!
  */
 
@@ -67,9 +68,9 @@ namespace NodeManager;
 public class NodeManagerPlugin : BaseSpaceWarpPlugin
 {
     // These are useful in case some other mod wants to add a dependency to this one
-    public const string ModGuid = MyPluginInfo.PLUGIN_GUID;
-    public const string ModName = MyPluginInfo.PLUGIN_NAME;
-    public const string ModVer = MyPluginInfo.PLUGIN_VERSION;
+    [PublicAPI] public const string ModGuid = MyPluginInfo.PLUGIN_GUID;
+    [PublicAPI] public const string ModName = MyPluginInfo.PLUGIN_NAME;
+    [PublicAPI] public const string ModVer = MyPluginInfo.PLUGIN_VERSION;
 
     public static NodeManagerPlugin Instance { get; set; }
 
@@ -216,7 +217,7 @@ public class NodeManagerPlugin : BaseSpaceWarpPlugin
         var gameState = Game?.GlobalGameState?.GetState();
         if (gameState == GameState.Map3DView) GUIenabled = true;
         if (gameState == GameState.FlightView) GUIenabled = true;
-        
+
         // Set the UI
         GUI.skin = Skins.ConsoleSkin;
         RefreshActiveVesselAndCurrentManeuver();
@@ -580,6 +581,8 @@ public class NodeManagerPlugin : BaseSpaceWarpPlugin
             }
         }
         ManeuverNodeData maneuverNodeData = new ManeuverNodeData(activeVessel.SimulationObject.GlobalId, isManeuver, burnUT);
+        maneuverNodeData.InitializeTransform();
+
         if (maneuverNodeData.IsOnManeuverTrajectory) // && patch != null)
             maneuverNodeData.SetManeuverState(patch as PatchedConicsOrbit);
 

--- a/node_manager/swinfo.json
+++ b/node_manager/swinfo.json
@@ -4,20 +4,20 @@
   "name": "Node Manager",
   "description": "Provides services for other mods needing to create, delete, and manage maneuver nodes",
   "source": "https://github.com/schlosrat/NodeManager",
-  "version": "0.7.0",
-  "spec": "1.3",
+  "version": "0.7.1",
+  "spec": "2.0",
   "version_check": "https://raw.githubusercontent.com/schlosrat/NodeManager/master/node_manager/swinfo.json",
   "dependencies": [
     {
       "id": "com.github.x606.spacewarp",
       "version": {
-        "min": "1.5.2",
+        "min": "1.7.0",
         "max": "*"
       }
     }
   ],
   "ksp2_version": {
-    "min": "0.1.5",
+    "min": "0.2.0",
     "max": "*"
   }
 }

--- a/node_manager/swinfo.json
+++ b/node_manager/swinfo.json
@@ -11,7 +11,7 @@
     {
       "id": "com.github.x606.spacewarp",
       "version": {
-        "min": "1.7.0",
+        "min": "1.6.0",
         "max": "*"
       }
     }


### PR DESCRIPTION
The initialization of a ManeuverNodeData object's transform has been moved outside of its constructor in KSP2 v0.2.0 into a separate method, this adds the call to that method in Node Manager, and sets the required game version to 0.2.0 and required SpaceWarp version to 1.6.0.